### PR TITLE
Fix inability to document published projects targeting .NET Core win-* runtime 

### DIFF
--- a/InheritDoc/InheritDoc.csproj
+++ b/InheritDoc/InheritDoc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>2.2.0</Version>
+        <Version>2.2.1</Version>
         <Description>Command line tool that post processes XML documentation files to support an <inheritdoc /> tag allowing inheriting XML comments from base types, interfaces, and similar methods. Works with .NET Framework, .NET Standard, and .NET Core projects. See the separate InheritDocLib NuGet package for a programmatic interface.</Description>
         <Company>Fireshark Studios, LLC</Company>
         <Copyright>Copyright ©  2017-2018</Copyright>
@@ -14,7 +14,7 @@
         <ApplicationIcon />
         <OutputType>Exe</OutputType>
         <StartupObject />
-        <PackageReleaseNotes>Rolled back support for VS 2019</PackageReleaseNotes>
+        <PackageReleaseNotes>Fix for published projects targeting .NET Core win-* runtime</PackageReleaseNotes>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GlobalTool)' != true">

--- a/InheritDocLib/InheritDocUtil.cs
+++ b/InheritDocLib/InheritDocUtil.cs
@@ -88,6 +88,17 @@ namespace InheritDocLib {
                 else if (matchingAssemblyFiles.Count() == 1) {
                     assemblyFiles.Add(matchingAssemblyFiles.First());
                 }
+                else if (matchingAssemblyFiles.Count() == 2 &&
+                         matchingAssemblyFiles.Any(f => f.EndsWith(".exe")) &&
+                         matchingAssemblyFiles.Any(f => f.EndsWith(".dll")))
+                {
+                    //.NET Core win-* publishing target creates 2 assemblies with the same name but different extensions:
+                    // MyAssembly.dll (contains actual code)
+                    // MyAssembly.exe (actually just a stub)
+                    // In this situation we take the .dll version
+
+                    assemblyFiles.Add(matchingAssemblyFiles.First(f => f.EndsWith(".dll")));
+                }
                 else if (matchingAssemblyFiles.Count() > 1) {
                     if (logger!=null) logger(LogLevel.Warn, $"GetAssemblyFiles():Found too many assemblies for xml file {xmlFile} ({string.Join(",", matchingAssemblyFiles)})");
                 }

--- a/InheritDocVsix/Properties/AssemblyInfo.cs
+++ b/InheritDocVsix/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]

--- a/InheritDocVsix/source.extension.vsixmanifest
+++ b/InheritDocVsix/source.extension.vsixmanifest
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="InheritDocVsix.75c8936d-7a76-4cc0-baed-4ecabc3b9e10" Version="2.2.0" Language="en-US" Publisher="Fireshark Studios, LLC" />
+        <Identity Id="InheritDocVsix.75c8936d-7a76-4cc0-baed-4ecabc3b9e10" Version="2.2.1" Language="en-US" Publisher="Fireshark Studios, LLC" />
         <DisplayName>InheritDoc</DisplayName>
         <Description xml:space="preserve">Allows using &lt;inheritdoc/&gt; tags in XML comments that copy and extend the XML comments from base types and interfaces
     </Description>
         <MoreInfo>http://www.inheritdoc.com/</MoreInfo>
         <GettingStartedGuide>index.html</GettingStartedGuide>
-        <ReleaseNotes>Rolled back support for VS 2019</ReleaseNotes>
+        <ReleaseNotes>Fix for published projects targeting .NET Core win-* runtime</ReleaseNotes>
         <Tags>inheritdoc inherit copy extend xml comments</Tags>
     </Metadata>
     <Installation>

--- a/www.inheritdoc.io/index.html
+++ b/www.inheritdoc.io/index.html
@@ -514,6 +514,7 @@ public class MyCoolDatabase : IDatabase {
         <section>
             <h3>Release Notes</h3>
             <ul>
+				<li>v2.2.1 (5/23/2019) - Fix for published projects targeting .NET Core win-* runtime</li>
                 <li>v2.2.0 (5/1/2019) - Deployed and rolled back support for VS 2019</li>
                 <li>v2.0.2 (10/23/2018) - Fixed wrong version number in VSIX package</li>
                 <li>v2.0.1 (10/23/2018) - Changed InheritDocLib to shared project to avoid loading issues for VSIX</li>


### PR DESCRIPTION
When publishing .NET Core application targeting win-x86 or win-x64 runtime two files for the main assembly are created, one containing the actual code (`*.dll`) and another (`*.exe`) that acts as a stub that allows to run the application without using cmd.
Currently InheritDoc refuses to create documentation for an assembly if it detects there are more than 1 similarly named files related to that assembly that differ only by extension. This pull request makes an exception if it finds both `.dll` and `.exe` files and prefers the first one over the second.

Also bumps version to 2.2.1