### PR TITLE
Add support of .NET Core SDK 3.1 and bump version to 2.4.0

### DIFF
--- a/InheritDoc/InheritDoc.csproj
+++ b/InheritDoc/InheritDoc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>2.3.0</Version>
+        <Version>2.4.0</Version>
         <Description>Command line tool that post processes XML documentation files to support an <inheritdoc /> tag allowing inheriting XML comments from base types, interfaces, and similar methods. Works with .NET Framework, .NET Standard, and .NET Core projects. See the separate InheritDocLib NuGet package for a programmatic interface.</Description>
         <Company>Fireshark Studios, LLC</Company>
         <Copyright>Copyright ©  2017-2018</Copyright>
@@ -26,7 +26,7 @@
     <PropertyGroup Condition="'$(GlobalTool)' == true">
         <PackageId>InheritDocTool</PackageId>
         <Description>.NET Core global tool that post processes XML documentation files to support an &amp;lt;inheritdoc/&amp;gt; tag allowing inheriting XML comments from base types, interfaces, and similar methods. Works with .NET Framework, .NET Standard, and .NET Core projects. See the separate InheritDocLib NuGet package for a programmatic interface.</Description>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
         <PackAsTool>true</PackAsTool>
     </PropertyGroup>
 


### PR DESCRIPTION
In this PR I have added support of .NET Core SDK 3.1. Now it's possible to build and use InheritDoc with this framework:

```
➜  InheritDoc git:(switch-to-sdk-3.1) ✗ dotnet --list-sdks
3.1.100 [/usr/local/share/dotnet/sdk]
➜  InheritDoc git:(switch-to-sdk-3.1) ✗ dotnet pack -c Release -o ./NuGet.local ./InheritDoc /p:GlobalTool=true
Microsoft (R) Build Engine version 16.4.0+e901037fe for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 38.56 ms for /Users/mdobryakov/Projects/work/vendor/forks/InheritDoc/InheritDoc/InheritDoc.csproj.
  InheritDoc -> /Users/mdobryakov/Projects/work/vendor/forks/InheritDoc/InheritDoc/bin/Release/netcoreapp3.1/InheritDoc.dll
  InheritDoc -> /Users/mdobryakov/Projects/work/vendor/forks/InheritDoc/InheritDoc/bin/Release/netcoreapp2.1/InheritDoc.dll
  Successfully created package '/Users/mdobryakov/Projects/work/vendor/forks/InheritDoc/NuGet.local/InheritDocTool.2.4.0.nupkg'.
/usr/local/share/dotnet/sdk/3.1.100/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(198,5): warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [/Users/mdobryakov/Projects/work/vendor/forks/InheritDoc/InheritDoc/InheritDoc.csproj]
/usr/local/share/dotnet/sdk/3.1.100/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(198,5): warning NU5048: The 'PackageIconUrl'/'iconUrl' element is deprecated. Consider using the 'PackageIcon'/'icon' element instead. Learn more at https://aka.ms/deprecateIconUrl [/Users/mdobryakov/Projects/work/vendor/forks/InheritDoc/InheritDoc/InheritDoc.csproj]
➜  InheritDoc git:(switch-to-sdk-3.1) ✗ dotnet tool install -g --add-source ./NuGet.local --version 2.4.0 InheritDocTool
You can invoke the tool using the following command: InheritDoc
Tool 'inheritdoctool' (version '2.4.0') was successfully installed.
➜  InheritDoc git:(switch-to-sdk-3.1) ✗ InheritDoc --help
InheritDoc 2.4.0
Copyright ©  2017-2018

  -b, --base                          Base path to look for XML document files (omit for current directory)

  -f, --xml-doc-file-name-patterns    Set to a comma delimited list of XML documentation file names to process (may use wild cards like 'Butterfly.*', leave blank to scan for assemblies in project files, do not include paths). Example:
                                      'Butterfly.Database.xml,Butterfly.Channel.*'

  -g, --global-source-xml-files       Set to a comma delimited list of xml files to search for source xml comments. Example: 'C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.X\mscorlib.xml

  -x, --exclude-types                 (Default: System.Object) Set to a comma delimited list of types to exclude from comments. Example: 'System.Object'

  -o, --overwrite                     Include to overwrite existing xml files. Omit to create new files with '.new.xml' suffix.

  --help                              Display this help screen.

  --version                           Display version information.
```

Looks like .NET Core SDK 2.1 should be supported too (I see compiled DLL for this version in *.nupkg).

P.S. Bump version to 2.4.0 to separate versions with and without .NET Core SDK 3.1 support.
