### PR TITLE
Small fix for sourceXml when multiple targets found.

### DIFF
--- a/InheritDocLib/XElementX.cs
+++ b/InheritDocLib/XElementX.cs
@@ -46,16 +46,25 @@ namespace InheritDocLib {
                 foreach (var pathPart in pathParts) {
                     var targetChildElements = targetCurrent.Elements(pathPart);
                     var sourceChildElements = sourceCurrent.Elements(pathPart);
-                    sourceCurrent = sourceChildElements.Single();
                     if (targetChildElements.Count()==0) {
                         var newTarget = new XElement(pathPart);
                         targetCurrent.Add(newTarget);
                         targetCurrent = newTarget;
+                        sourceCurrent = sourceChildElements.Single();
                     }
                     else if (targetChildElements.Count()==1) {
                         targetCurrent = targetChildElements.Single();
+                        if (sourceChildElements.Count() == 1)
+                        {
+                            sourceCurrent = sourceChildElements.Single();
+                        }
+                        else
+                        {
+                            sourceCurrent = sourceChildElements.Single(s => s.Attribute("name")?.Value == targetCurrent.Attribute("name")?.Value);
+                        }
                     }
                     else {
+                        sourceCurrent = sourceChildElements.Single();
                         var reader = sourceCurrent.Parent.CreateReader();
                         reader.MoveToContent();
                         var sourceXml = reader.ReadInnerXml();

--- a/InheritDocTest/InheritDocTest.cs
+++ b/InheritDocTest/InheritDocTest.cs
@@ -242,7 +242,7 @@ namespace InheritDocTest {
                     xDocument,
                     "MyException",
                     "summary",
-                    new string[] { "Represents errors that occur during application execution.To browse the .NET Framework source code for this type, see the Reference Source." }
+                    new string[] { "Represents errors that occur during application execution." }
                 );
 
                 CheckForMethodComments(


### PR DESCRIPTION
https://github.com/firesharkstudios/InheritDoc/pull/23 introduced an issue when there is a single target and multiple sources.

This fixes this edge case, filtering by the same name as the target.
Also fixed a broken test.